### PR TITLE
Add --with-default-mixerapp configure option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -86,6 +86,13 @@ AC_SUBST(OSS_CFLAGS)
 
 AM_CONDITIONAL(ENABLE_OSS, test "$oss" = "yes")
 
+DEFAULT_MIXERAPP="xterm -e 'alsamixer'"
+AC_ARG_WITH(default-mixerapp,
+[  --with-default-mixerapp=appname
+                           Default command for "Open Mixer" menu item
+                           (default: "xterm -e 'alsamixer'")],
+DEFAULT_MIXERAPP=$withval)
+AC_DEFINE_UNQUOTED(DEFAULT_MIXERAPP,"${DEFAULT_MIXERAPP}",[Default mixer application])
 
 AC_CONFIG_FILES(Makefile \
 		src/Makefile \

--- a/src/config.c
+++ b/src/config.c
@@ -60,7 +60,7 @@ static gboolean m_use_transparent_background = FALSE;
 static void config_load_default()
 {
 	if(!m_helper_program)
-		config_set_helper("xterm -e 'alsamixer'");
+		config_set_helper(DEFAULT_MIXERAPP);
 	if(!m_channel)
 		config_set_channel(NULL);
 	if(!m_card)


### PR DESCRIPTION
This adds a new configure option: `--with-default-mixerapp` which defaults to `"xterm -e 'alsamixer'"` which is what was being used without asking now. This won't change builds that don't specify it.

I get tired of the default mixer, and sometimes I want a graphical one. Plus, more flexibility is generally a good thing, right?

(The `--with-default-mixerapp` option name comes from the [mhwaveedit](https://github.com/magnush/mhwaveedit/blob/master/configure.in#L64) project.)
