### PR TITLE
Fix compile error when enabling oss

### DIFF
--- a/src/oss_backend.c
+++ b/src/oss_backend.c
@@ -26,10 +26,7 @@
 #include <fcntl.h>
 #include <assert.h>
 #include <stdlib.h>
-#include <glib/gstring.h>
-#include <glib/gstdio.h>
-#include <glib/glist.h>
-#include <glib/giochannel.h>
+#include <glib.h>
 
 #include "oss_backend.h"
 


### PR DESCRIPTION
Starting with glib 2.32 it is mandatory to include glib.h instead
of individual headers.
Similar to issue #12 .
