### PR TITLE
Fix gtk_widget_get_root_window deprecation

### DIFF
--- a/src/volumeicon.c
+++ b/src/volumeicon.c
@@ -669,7 +669,7 @@ static gboolean scale_timeout(gpointer data)
 	GdkDevice *pointer;
 	gint x, y;
 
-	root_window = gtk_widget_get_root_window(m_scale_window);
+	root_window = gdk_screen_get_root_window(gtk_widget_get_screen(m_scale_window));
 	device_manager = gdk_display_get_device_manager(gdk_window_get_display(root_window));
 	pointer = gdk_device_manager_get_client_pointer(device_manager);
 	gdk_window_get_device_position(root_window, pointer, &x, &y, NULL);


### PR DESCRIPTION
The function gtk_widget_get_root_window has been depcreated in GTK+ 3.12
in favor of gdk_screen_get_root_window. This gets rid of the deprecation warning.
