### PR TITLE
Add option to use decibel scale as before df1d6293817e.

### DIFF
--- a/data/gui/preferences.ui
+++ b/data/gui/preferences.ui
@@ -189,6 +189,29 @@
                                         <property name="position">1</property>
                                       </packing>
                                     </child>
+                                    <child>
+                                      <object class="GtkRadioButton" id="linear_radiobutton">
+                                        <property name="label" translatable="yes">Linear Scale</property>
+                                        <property name="visible">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">True</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">2</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkRadioButton" id="decibel_radiobutton">
+                                        <property name="label" translatable="yes">Decibel Scale</property>
+                                        <property name="visible">True</property>
+                                        <property name="group">linear_radiobutton</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">True</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">3</property>
+                                      </packing>
+                                    </child>
                                   </object>
                                 </child>
                               </object>

--- a/src/alsa_backend.c
+++ b/src/alsa_backend.c
@@ -29,6 +29,7 @@
 
 #include "alsa_backend.h"
 #include "alsa_volume_mapping.h"
+#include "config.h"
 
 //##############################################################################
 // Static variables
@@ -107,7 +108,15 @@ int asound_get_volume()
 	}
 
 	// Return the current volume value from [0-100]
-	return rint(100 * get_normalized_playback_volume(m_elem, 0));
+	if(config_get_decibel_scale())
+	{
+		long pmin, pmax, value;
+		snd_mixer_selem_get_playback_volume_range(m_elem, &pmin, &pmax);
+		snd_mixer_selem_get_playback_volume(m_elem, 0, &value);
+		return 100 * (value - pmin) / (pmax - pmin);
+	}
+	else
+		return rint(100 * get_normalized_playback_volume(m_elem, 0));
 }
 
 gboolean asound_get_mute()
@@ -286,5 +295,13 @@ void asound_set_volume(int volume)
 	}
 	volume = (volume < 0 ? 0 : (volume > 100 ? 100 : volume));
 
-	set_normalized_playback_volume_all(m_elem, volume / 100.0, 0);
+	if(config_get_decibel_scale())
+	{
+		long pmin, pmax;
+		snd_mixer_selem_get_playback_volume_range(m_elem, &pmin, &pmax);
+		long value = pmin + (pmax-pmin) * volume / 100;
+		snd_mixer_selem_set_playback_volume_all(m_elem, value);
+	}
+	else
+		set_normalized_playback_volume_all(m_elem, volume / 100.0, 0);
 }

--- a/src/config.c
+++ b/src/config.c
@@ -41,6 +41,7 @@ static struct config {
     // Alsa
     gchar *card; // TODO: Rename this to device.
     gchar *channel;
+    gboolean decibel_scale;
 
     // Notifications
     gboolean show_notification;
@@ -76,6 +77,7 @@ static struct config {
     // Alsa
     .card = NULL,
     .channel = NULL,
+    .decibel_scale = FALSE,
 
     // Notifications
     .show_notification = TRUE,
@@ -151,6 +153,7 @@ static void config_read(void)
     // Alsa
     m_config.card = GET_STRING("Alsa", "card");
     m_config.channel = GET_STRING("Alsa", "channel");
+    m_config.decibel_scale = GET_BOOL("Alsa", "decibel_scale");
 
     // Notifications
     m_config.show_notification = GET_BOOL("Notification", "show_notification");
@@ -210,6 +213,11 @@ void config_set_channel(const gchar *channel)
 {
     g_free(m_config.channel);
     m_config.channel = g_strdup(channel);
+}
+
+void config_set_decibel_scale(gboolean decibel_scale)
+{
+    m_config.decibel_scale = decibel_scale;
 }
 
 // Notifications
@@ -321,6 +329,11 @@ const gchar *config_get_card(void)
 const gchar *config_get_channel(void)
 {
     return m_config.channel;
+}
+
+gboolean config_get_decibel_scale()
+{
+    return m_config.decibel_scale;
 }
 
 // Notifications
@@ -439,6 +452,7 @@ void config_write(void)
         SET_STRING("Alsa", "card", m_config.card);
     if(m_config.channel)
         SET_STRING("Alsa", "channel", m_config.channel);
+    SET_BOOL("Alsa", "decibel_scale", m_config.decibel_scale);
 
     // Notifications
     SET_BOOL("Notification", "show_notification", m_config.show_notification);

--- a/src/config.h
+++ b/src/config.h
@@ -31,6 +31,7 @@
 // Alsa
 void config_set_card(const gchar *card);
 void config_set_channel(const gchar *channel);
+void config_set_decibel_scale(gboolean decibel_scale);
 
 // Notifications
 void config_set_show_notification(gboolean active);
@@ -68,6 +69,7 @@ void config_set_hotkey_mute(const gchar *mute);
 // Alsa
 const gchar *config_get_card(void);
 const gchar *config_get_channel(void);
+gboolean config_get_decibel_scale(void);
 
 // Notifications
 gboolean config_get_show_notification(void);

--- a/src/volumeicon.c
+++ b/src/volumeicon.c
@@ -95,6 +95,8 @@ typedef struct
 	GtkCheckButton * use_panel_specific_icons_checkbutton;
 	GtkListStore * hotkey_store;
 	GtkButton * close_button;
+	GtkRadioButton * linear_radiobutton;
+	GtkRadioButton * decibel_radiobutton;
 	GtkRadioButton * mute_radiobutton;
 	GtkRadioButton * slider_radiobutton;
 	GtkRadioButton * mmb_mute_radiobutton;
@@ -225,6 +227,18 @@ static void preferences_close_button_clicked(GtkWidget * widget,
 	gpointer user_data)
 {
 	gtk_widget_destroy(gui->window);
+}
+
+static void preferences_decibel_radiobutton_toggled(GtkToggleButton * togglebutton,
+	gpointer user_data)
+{
+	gboolean decibel_scale = gtk_toggle_button_get_active(togglebutton);
+	config_set_decibel_scale(decibel_scale);
+
+	m_volume = clamp_volume(backend_get_volume());
+	m_mute = backend_get_mute();
+	status_icon_update(m_mute, TRUE);
+	scale_update();
 }
 
 static void preferences_mute_radiobutton_toggled(GtkToggleButton * togglebutton,
@@ -492,6 +506,8 @@ static void menu_preferences_on_activate(GtkMenuItem * menuitem,
 	gui->use_panel_specific_icons_checkbutton = GTK_CHECK_BUTTON(getobj("use_panel_specific_icons_checkbutton"));
 	gui->hotkey_store = GTK_LIST_STORE(getobj("hotkey_binding_model"));
 	gui->close_button = GTK_BUTTON(getobj("close_button"));
+	gui->linear_radiobutton = GTK_RADIO_BUTTON(getobj("linear_radiobutton"));
+	gui->decibel_radiobutton = GTK_RADIO_BUTTON(getobj("decibel_radiobutton"));
 	gui->mute_radiobutton = GTK_RADIO_BUTTON(getobj("mute_radiobutton"));
 	gui->slider_radiobutton = GTK_RADIO_BUTTON(getobj("slider_radiobutton"));
 	gui->mmb_mute_radiobutton = GTK_RADIO_BUTTON(getobj("mmb_mute_radiobutton"));
@@ -510,6 +526,17 @@ static void menu_preferences_on_activate(GtkMenuItem * menuitem,
 	gtk_window_set_default_icon_from_file(APP_ICON, NULL);
 
 	// Set the radiobuttons
+	if(config_get_decibel_scale())
+	{
+		gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(gui->decibel_radiobutton),
+			TRUE);
+	}
+	else
+	{
+		gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(gui->linear_radiobutton),
+			TRUE);
+	}
+
 	if(config_get_left_mouse_slider())
 	{
 		gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(gui->slider_radiobutton),
@@ -628,6 +655,8 @@ static void menu_preferences_on_activate(GtkMenuItem * menuitem,
 		G_OBJECT(gui->use_panel_specific_icons_checkbutton), "toggled",
 		G_CALLBACK(preferences_use_panel_specific_icons_checkbutton_toggled),
 		NULL);
+	g_signal_connect(G_OBJECT(gui->decibel_radiobutton), "toggled", G_CALLBACK(
+		preferences_decibel_radiobutton_toggled), NULL);
 	g_signal_connect(G_OBJECT(gui->mute_radiobutton), "toggled", G_CALLBACK(
 		preferences_mute_radiobutton_toggled), NULL);
 	g_signal_connect(G_OBJECT(gui->mmb_mixer_radiobutton), "toggled", G_CALLBACK(


### PR DESCRIPTION
I prefer this type of volume control, where a 10% adjustment on the scale always changes the volume by the same number of decibels.  (Compare with alsamixer, where from 5% to 15% is a 30 dB change, while from 85% to 95% is only 3 dB.)  Can the decibel scale be made an option again?

This replaces my earlier pull request.