### PR TITLE
Add missing space in NOTIFY_CFLAGS.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -86,7 +86,7 @@ fi
 if test "x${notify}" = xyes; then
 # Check for libnotify
 PKG_CHECK_MODULES([NOTIFY], [libnotify >= 0.5.0])
-NOTIFY_CFLAGS+="-DCOMPILEWITH_NOTIFY"
+NOTIFY_CFLAGS+=" -DCOMPILEWITH_NOTIFY"
 AC_SUBST(NOTIFY_CFLAGS)
 AC_SUBST(NOTIFY_LIBS)
 fi


### PR DESCRIPTION
On Arch Linux ARM, -DCOMPILEWITH_NOTIFY was getting added immediately onto the end of the last include path in NOTIFY_CFLAGS without an intervening space and thus didn't get interpreted correctly as a separate option.  Probably didn't matter on some other systems since NOTIFY_CFLAGS might have already ended in a space.