### PR TITLE
notification on mute

### DIFF
--- a/src/volumeicon.c
+++ b/src/volumeicon.c
@@ -815,6 +815,7 @@ static gboolean status_icon_on_button_press(GtkStatusIcon * status_icon,
 		backend_set_volume(m_volume);
 		backend_set_mute(m_mute);
 		status_icon_update(m_mute, FALSE);
+		notification_show();
 	}
 	else if(event->button == 2)
 	{


### PR DESCRIPTION
I added notification_show() in the handler for icon clicking to notify the muting. This is consistent with the notification_show() in the hotkey handler.