### PR TITLE
bugfix: enable options translation in command line

### DIFF
--- a/src/volumeicon.c
+++ b/src/volumeicon.c
@@ -1249,14 +1249,18 @@ int main(int argc, char * argv[])
 	gboolean print_version = FALSE;
 	GOptionEntry options[] = {
 		{ "config", 'c', 0, G_OPTION_ARG_FILENAME, &config_name,
-			_("Alternate name to use for config file, default is volumeicon"), "name" },
+			N_("Alternate name to use for config file, default is volumeicon"), "name" },
 		{ "device", 'd', 0, G_OPTION_ARG_STRING, &device_name,
-			_("Mixer device name"), "name" },
+			N_("Mixer device name"), "name" },
 		{ "version", 'v', 0, G_OPTION_ARG_NONE, &print_version,
-			_("Output version number and exit"), NULL },
+			N_("Output version number and exit"), NULL },
 		{ NULL }
 	};
-	if(!gtk_init_with_args(&argc, &argv, "", options, "", &error)) {
+	GOptionContext *context = g_option_context_new (NULL);
+	g_option_context_set_translation_domain(context, GETTEXT_PACKAGE);
+	g_option_context_add_main_entries (context, options, GETTEXT_PACKAGE);
+	g_option_context_add_group (context, gtk_get_option_group (TRUE));
+	if(!g_option_context_parse (context, &argc, &argv, &error)) {
 		if(error) {
 			g_printerr("%s\n", error->message);
 		}


### PR DESCRIPTION
Bugfix with option parse. In version 0.5.1 only native options have a translation with --help. 


For example. (version 0.5.1)
```
Использование:
  volumeicon [ПАРАМЕТР…] 

Параметры справки:
  -h, --help               Показать параметры справки
  --help-all               Показать все параметры справки
  --help-gtk               Показать параметры GTK+

Параметры приложения:
  -c, --config=name        Alternate name to use for config file, default is volumeicon
  -d, --device=name        Mixer device name
  -v, --version            Output version number and exit
  --display=ДИСПЛЕЙ        Используемый X-дисплей

```

With my patch:
```
Использование:
  volumeicon [ПАРАМЕТР…]

Параметры справки:
  -h, --help               Показать параметры справки
  --help-all               Показать все параметры справки
  --help-gtk               Показать параметры GTK+

Параметры приложения:
  -c, --config=name        Альтернативное имя для конфигурационного файла, по умолчанию: volumeicon
  -d, --device=name        Название устройства миксера
  -v, --version            Вывести номер версии и выйти
  --display=ДИСПЛЕЙ        Используемый X-дисплей
```