### PR TITLE
Patch translation text aligment in hotkeys preferences

### DIFF
--- a/data/gui/preferences.ui
+++ b/data/gui/preferences.ui
@@ -695,8 +695,9 @@
                                 </child>
                                 <child>
                                   <object class="GtkTreeViewColumn" id="treeviewcolumn1">
+                                    <property name="resizable">True</property>
                                     <property name="sizing">fixed</property>
-                                    <property name="fixed_width">160</property>
+                                    <property name="min_width">160</property>
                                     <property name="title">column</property>
                                     <child>
                                       <object class="GtkCellRendererText" id="cellrenderertext3"/>


### PR DESCRIPTION
In version 0.5.1 translation text have uncorrect alignment in hotkey preferences.

Bug example (version 0.5.1):
![3851x_croper_ru](https://cloud.githubusercontent.com/assets/1816035/13718143/00f379a0-e809-11e5-9a8d-2d365a7b9169.png)
Patched version:
![6cehr_croper_ru](https://cloud.githubusercontent.com/assets/1816035/13718144/04c92cd2-e809-11e5-8889-dd5e3351ad68.png)