### PR TITLE
Added manpage for section 1 and section 5

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
 AUTOMAKE_OPTIONS = foreign
-SUBDIRS = src data po
+SUBDIRS = src data doc po
 
 pkgconfigdir = $(datadir)/volumeicon

--- a/configure.ac
+++ b/configure.ac
@@ -106,6 +106,7 @@ AC_DEFINE_UNQUOTED(DEFAULT_MIXERAPP,"${DEFAULT_MIXERAPP}",[Default mixer applica
 AC_CONFIG_FILES(Makefile \
 		src/Makefile \
 		data/Makefile \
+		doc/Makefile \
 		po/Makefile.in)
 
 AC_OUTPUT

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1,0 +1,14 @@
+EXTRA_DIST = volumeicon.1.pod volumeicon.5.pod
+
+dist_man_MANS = volumeicon.1 volumeicon.5
+
+volumeicon.1: volumeicon.1.pod
+	pod2man --release='${PACKAGE_VERSION}' --center='${PACKAGE_NAME}' \
+		--section=1 $< > $@
+
+volumeicon.5: volumeicon.5.pod
+	pod2man --release='${PACKAGE_VERSION}' --center='${PACKAGE_NAME}' \
+		--section=5 $< > $@
+
+CLEANFILES = volumeicon.1 volumeicon.5
+

--- a/doc/volumeicon.1.pod
+++ b/doc/volumeicon.1.pod
@@ -1,5 +1,7 @@
 =pod
 
+=encoding utf8
+
 =head1 NAME
 
 volumeicon - A lightweight standalone volume icon indicator 
@@ -25,7 +27,7 @@ Alternate configuration file. Default is B<~/.config/volumeicon/volumeicon>. Ref
 
 Mixer device name
 
-=item B<-v --version>
+=item B<-v, --version>
 
 Output version number and exit
 
@@ -87,7 +89,7 @@ Changed volume mapping to match that of alsamixer (code from alsamixer).
 
 =item Dan Church
 
-Added `--with-default-mixerapp' configur option.
+Added `--with-default-mixerapp' configure option.
 
 =item Valère Monseur
 

--- a/doc/volumeicon.1.pod
+++ b/doc/volumeicon.1.pod
@@ -1,0 +1,116 @@
+=pod
+
+=head1 NAME
+
+volumeicon - A lightweight standalone volume icon indicator 
+
+=head1 SYNOPSIS
+
+B<volumeicon --config=CONFIGFILE --device=MIXER --display=DISPLAY>
+B<volumeicon --version>
+
+=head1 DESCRIPTION
+
+This app is a standalone lightweight volume icon, desktop independent, which sits on the system tray.
+
+volumeicon accepts the following parameters.
+
+=over 4
+
+=item B<-c, --config=CONFIGFILE>
+
+Alternate configuration file. Default is B<~/.config/volumeicon/volumeicon>. Refer to L<volumeicon(5)> for configuration file information.
+
+=item B<-d, --device=MIXER>
+
+Mixer device name
+
+=item B<-v --version>
+
+Output version number and exit
+
+=item B<--display=DISPLAY>
+
+X display to use
+
+=back
+
+=head1 BUGS
+
+Submit bug reports and pull requests to L<Github|https://github.com/Maato/volumeicon>
+
+=head1 AUTHORS
+
+=over 4
+
+=item Maato <maato@softwarebakery.com>
+
+Developer
+
+=item Niklas Koep <niklas.koep@gmail.com>
+
+Lots of fixes, and help on github.
+ 
+=item David Gidwani <david.gidwani@gmail.com>
+
+Hotkey support
+ 
+=item Mihail Szabolcs
+
+Notifications
+
+=item Matthias Frei
+
+Show notification only when hotkeys are pressed or when scrolling the icon.
+
+Make the volume slider popup downwards if no space is left above the icon.
+
+=item Jean-Pierre Demailly <demailly@fourier.ujf-grenoble.fr>
+
+Option to use a horizontal slider
+
+Option to show the numerical value of the sound level on the slider
+
+=item Matt Boyer
+
+Added support for 8-bit OSS sliders and improved configure.ac for OSS
+
+=item Gauvain Pocentek
+
+Port to GTK 3
+
+Added french translation.
+
+=item Revellian
+
+Changed volume mapping to match that of alsamixer (code from alsamixer).
+
+=item Dan Church
+
+Added `--with-default-mixerapp' configur option.
+
+=item Valère Monseur
+
+Added option for transparent slider background.
+
+Various small fixes.
+
+=item Steven Honeyman
+
+Only use gtk -panel icons if they exist.
+
+=item Mateusz Łukasik <mati75@linuxmint.pl>
+
+Polish translation
+
+=back
+
+=head1 LICENSE
+
+This program is licensed under GNU General Public License version 3. See B<COPYING> in the distribution for detailed license text.
+
+=head1 SEE ALSO
+
+L<volumeicon(5)>, L<alsamixer(1)>
+
+=cut

--- a/doc/volumeicon.5.pod
+++ b/doc/volumeicon.5.pod
@@ -120,6 +120,8 @@ Hotkey to toggle mute. The default is B<XF86AudioMute>.
 
 =back
 
+=back
+
 =head1 BUGS
 
 Submit bug reports and pull requests to L<Github|https://github.com/Maato/volumeicon>

--- a/doc/volumeicon.5.pod
+++ b/doc/volumeicon.5.pod
@@ -1,5 +1,7 @@
 =pod
 
+=encoding utf8
+
 =head1 NAME
 
 volumeicon - configuration file for L<volumeicon(1)>

--- a/doc/volumeicon.5.pod
+++ b/doc/volumeicon.5.pod
@@ -1,0 +1,135 @@
+=pod
+
+=head1 NAME
+
+volumeicon - configuration file for L<volumeicon(1)>
+
+=head1 SYNOPSIS
+
+B<~/.config/volumeicon/volumeicon>
+
+=head1 DESCRIPTION
+
+L<volumeicon(1)> obtains configuration information from B<~/.config/volumeicon/volumeicon>. This configuration file can be overriden on runtime via B<--config> switch.
+
+The configuration syntax is similar of those .ini files.
+
+=over 4
+
+=item B<[Alsa]>
+
+This section holds alsa sound card configuration.
+
+=over 4
+
+=item B<card>
+
+Specify which sound card to control. The default value is B<default>.
+
+=back
+
+=item B<[Notification]>
+
+This section holds notification configuration.
+
+=over 4
+
+=item B<show_notification>
+
+The value can be either B<true> to enable notification or B<false> to disable notification.
+
+=item B<notification_type>
+
+The value can be either B<1> for libnotify based notification or B<0> for GTK+ popup notification.
+
+=back
+
+=item B<[StatusIcon]>
+
+This section holds status icon configuration. The configuration items are as follows.
+
+=over 4
+
+=item B<stepsize>
+
+Configure how many steps when changing volume. Takes an integer value. The default is B<5>.
+
+=item B<onclick>
+
+Configure the command executed when clicking B<volumeicon(1)> applet. The default is B<xterm -e 'alsamixer'>.
+
+=item B<theme>
+
+Icon theme to use. The default is B<tango>
+
+=item B<use_panel_specific_icons>
+
+Whether to use panel-provided icon. The default is B<false>.
+
+=item B<lmb_slider>
+
+Whether to show volume slider. The default is B<false>.
+
+=item B<mmb_mute>
+
+whether to use middle mouse button to toggle mute. The default is B<false>.
+
+=item B<use_horizontal_slider>
+
+Whether to use horizontal slider. The default is B<true>.
+
+=item B<show_sound_level>
+
+Whether to show sound level. The default is B<false>.
+
+=item B<use_transparent_background>
+
+Whether to use transparent background. The default is B<false>.
+
+=back
+
+=item B<[Hotkeys]>
+
+This section holds the hotkey configuration for volume manipulation.
+
+=over 4
+
+=item B<up_enabled>
+
+Whether to enable volume up hotkey. The default is B<false>.
+
+=item B<down_enabled>
+
+whether to enable volume down hotkey. The default is B<false>.
+
+=item B<mute_enabled>
+
+Whether to enable volume mute hotkey. The default is B<false>.
+
+=item B<up>
+
+Hotkey to increase volume. The default is B<XF86AudioRaiseVolume>.
+
+=item B<down>
+
+Hotkey to decrease volume. The default is B<XF86AudioLowerVolume>.
+
+=item B<mute>
+
+Hotkey to toggle mute. The default is B<XF86AudioMute>.
+
+=back
+
+=head1 BUGS
+
+Submit bug reports and pull requests to L<Github|https://github.com/Maato/volumeicon>
+
+=head1 LICENSE
+
+This program is licensed under GNU General Public License version 3. See B<COPYING> in the distribution for detailed license text.
+
+=head1 SEE ALSO
+
+L<volumeicon(1)>, L<alsamixer(1)>, L<xev(1)>
+
+=cut


### PR DESCRIPTION
The manual page is in pod format. pod2man is needed to generate the
final manual page. No changes to makefile and build system. Please make
a Makefile.am and modify the build system accordingly so that 'make
install' also install the manpage.