### PR TITLE
Reverse scroll directions

### DIFF
--- a/data/gui/preferences.ui
+++ b/data/gui/preferences.ui
@@ -389,6 +389,21 @@
                                         <property name="position">1</property>
                                       </packing>
                                     </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="reverse_scroll_direction_checkbutton">
+                                        <property name="label" translatable="yes">Reverse scroll direction for volume adjustment</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="xalign">0</property>
+                                        <property name="draw_indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">2</property>
+                                      </packing>
+                                    </child>
                                   </object>
                                 </child>
                               </object>

--- a/src/config.c
+++ b/src/config.c
@@ -52,6 +52,7 @@ static struct config {
 	gchar *helper_program;
 	gchar *theme;
 	gboolean use_panel_specific_icons;
+	gboolean reverse_scroll_direction;
 
 	// Left mouse button action
 	gboolean lmb_slider;
@@ -87,6 +88,7 @@ static struct config {
               .helper_program = NULL,
               .theme = NULL,
               .use_panel_specific_icons = FALSE,
+              .reverse_scroll_direction = FALSE,
 
               // Left mouse button action
               .lmb_slider = FALSE,
@@ -163,6 +165,8 @@ static void config_read(void)
 	m_config.theme = GET_STRING("StatusIcon", "theme");
 	m_config.use_panel_specific_icons =
 	    GET_BOOL("StatusIcon", "use_panel_specific_icons");
+	m_config.reverse_scroll_direction =
+	    GET_BOOL("StatusIcon", "reverse_scroll_direction");
 
 	// Left mouse button action
 	m_config.lmb_slider = GET_BOOL("StatusIcon", "lmb_slider");
@@ -247,6 +251,11 @@ void config_set_theme(const gchar *theme)
 void config_set_use_panel_specific_icons(gboolean active)
 {
 	m_config.use_panel_specific_icons = active;
+}
+
+void config_set_reverse_scroll_direction(gboolean active)
+{
+	m_config.reverse_scroll_direction = active;
 }
 
 // Left mouse button action
@@ -350,6 +359,11 @@ gboolean config_get_use_panel_specific_icons(void)
 	return m_config.use_panel_specific_icons;
 }
 
+gboolean config_get_reverse_scroll_direction(void)
+{
+	return m_config.reverse_scroll_direction;
+}
+
 // Left mouse button action
 gboolean config_get_left_mouse_slider(void) { return m_config.lmb_slider; }
 
@@ -428,6 +442,8 @@ void config_write(void)
 		SET_STRING("StatusIcon", "theme", m_config.theme);
 	SET_BOOL("StatusIcon", "use_panel_specific_icons",
 	         m_config.use_panel_specific_icons);
+	SET_BOOL("StatusIcon", "reverse_scroll_direction",
+	         m_config.reverse_scroll_direction);
 
 	// Left mouse button action
 	SET_BOOL("StatusIcon", "lmb_slider", m_config.lmb_slider);

--- a/src/config.h
+++ b/src/config.h
@@ -42,6 +42,7 @@ void config_set_stepsize(int stepsize);
 void config_set_helper(const gchar *helper);
 void config_set_theme(const gchar *theme);
 void config_set_use_panel_specific_icons(gboolean active);
+void config_set_reverse_scroll_direction(gboolean active);
 
 // Left mouse button action
 void config_set_left_mouse_slider(gboolean active);
@@ -81,6 +82,7 @@ const gchar *config_get_helper(void);
 const gchar *config_get_theme(void);
 gboolean config_get_use_gtk_theme(void);
 gboolean config_get_use_panel_specific_icons(void);
+gboolean config_get_reverse_scroll_direction(void);
 
 // Left mouse button action
 gboolean config_get_left_mouse_slider(void);


### PR DESCRIPTION
If one is using Synaptics touchpad with [natural scrolling](https://wiki.archlinux.org/index.php/Touchpad_Synaptics#Natural_scrolling), it might be more convenient to invert (counteract used input driver tweak) scrolling directions for tray icon.

I know, that this feature might be very specific to my setup. Anyhow, I've though, that it will be nice to share this idea.